### PR TITLE
bugfix: revert tor virtual port to always map to internal port

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -475,8 +475,8 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
             private_key = "NEW:ED25519-V3"; // Explicitly request key type - see issue #9214
         }
         // Request onion service, redirect port.
-        // Note that the 'virtual' port is always the default port to avoid decloaking nodes using other ports.
-        _conn.Command(strprintf("ADD_ONION %s Port=%i,127.0.0.1:%i", private_key, GetListenPort()),
+        // Note that the 'virtual' port doesn't have to be the same as our internal port, but this is just a convenient
+        _conn.Command(strprintf("ADD_ONION %s Port=%i,127.0.0.1:%i", private_key, GetListenPort(), GetListenPort()),
             std::bind(&TorController::add_onion_cb, this, std::placeholders::_1, std::placeholders::_2));
     } else {
         LogPrintf("tor: Authentication failed\n");
@@ -718,4 +718,3 @@ void StopTorControl()
         base = 0;
     }
 }
-


### PR DESCRIPTION
Reverts to existing torv2 port logic because we don't have all the novel multi-port features in yet 

(from what I think was coming in with Bitcoin Core 22.0)

feel free to squash