### PR TITLE
net: correctly deserialize addresses

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -428,7 +428,7 @@ class CNetAddr
 
             if (SetNetFromBIP155Network(bip155_net, address_size)) {
                 m_addr.resize(address_size);
-                s >> m_addr;
+                s >> REF(MakeSpan(m_addr));
 
                 if (m_net != NET_IPV6) {
                     return;


### PR DESCRIPTION
Fixes deserialization into `CNetAddr.m_addr` - makes `net_tests` pass on x86_64 linux/win and aarch64, macos and 32-bit builds still need a lot of love.