### PR TITLE
Add native support for serializing char arrays without FLATDATA

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -522,18 +522,18 @@ class CSubNet
 
         template <typename Stream, typename Operation>
         inline void SerializationOp(Stream& s, Operation ser_action) {
-            READWRITE(FLATDATA(network));
+            READWRITE(network);
             if (network.IsIPv4()) {
                 // Before commit 102867c587f5f7954232fb8ed8e85cda78bb4d32, CSubNet used the last 4 bytes of netmask
                 // to store the relevant bytes for an IPv4 mask. For compatiblity reasons, keep doing so in
                 // serialized form.
                 unsigned char dummy[12] = {0};
-                READWRITE(FLATDATA(dummy));
-                READWRITE(FLATDATA(REF(MakeSpan(netmask).first(4))));
+                READWRITE(dummy);
+                READWRITE(REF(MakeSpan(netmask).first(4)));
             } else {
-                READWRITE(FLATDATA(netmask));
+                READWRITE(netmask);
             }
-            READWRITE(FLATDATA(valid));
+            READWRITE(valid);
         }
 };
 


### PR DESCRIPTION
This commit contains a subset of changes to netaddress.h from the following cherry-pick:

a7c45bc Add native support for serializing char arrays without FLATDATA 